### PR TITLE
Fixed GitHub spelling in navigation

### DIFF
--- a/_data/navigation.yml
+++ b/_data/navigation.yml
@@ -17,12 +17,9 @@ main:
     - title: "Community"
       subnav: "community"
       subnavLinks:
-          - name: "Github"
+          - name: "GitHub"
             subnavLink: "https://github.com/wiremock/wiremock"
           - name: "Contributing"
             subnavLink: "https://github.com/wiremock/wiremock/blob/master/CONTRIBUTING.md"
           - name: "Resources"
             subnavLink: /external-resources
-
-    
-      

--- a/_includes/author-profile.html
+++ b/_includes/author-profile.html
@@ -59,7 +59,7 @@
         <li><a href="https://bitbucket.org/{{ author.bitbucket }}"><i class="fa fa-fw fa-bitbucket" aria-hidden="true"></i> Bitbucket</a></li>
       {% endif %}
       {% if author.github %}
-        <li><a href="https://github.com/{{ author.github }}"><i class="fa fa-fw fa-github" aria-hidden="true"></i> Github</a></li>
+        <li><a href="https://github.com/{{ author.github }}"><i class="fa fa-fw fa-github" aria-hidden="true"></i> GitHub</a></li>
       {% endif %}
       {% if author.stackoverflow %}
         <li><a href="https://www.stackoverflow.com/users/{{ author.stackoverflow }}"><i class="fa fa-fw fa-stack-overflow" aria-hidden="true"></i> Stackoverflow</a></li>

--- a/_includes/masthead.html
+++ b/_includes/masthead.html
@@ -145,7 +145,7 @@
             </a>
           </li>
           <li><a href="/support">Support</a></li>
-          <li><a href="https://github.com/wiremock/wiremock" target="_blank">Github</a></li>
+          <li><a href="https://github.com/wiremock/wiremock" target="_blank">GitHub</a></li>
           <li><a href="https://github.com/wiremock/wiremock/blob/master/CONTRIBUTING.md" target="_blank">Contributing</a></li>
           <li><a href="/external-resources">Resources</a></li>
         </ul>


### PR DESCRIPTION
I noticed the incorrect capitalization of GitHub in the navigation bar. Currently it is incorrectly spelled as 'Github'.

It should be spelled as 'GitHub'. This pull request fixes the capital letter.