### PR TITLE
Fixed CSS classnames appearing in plain text

### DIFF
--- a/index.html
+++ b/index.html
@@ -312,22 +312,22 @@ docker run -it --rm \
       <h2>FAQ</h2>
       <dl class="faq-list">
         <dt><i class="faq-list-arrow"></i> What is WireMock?</dt>
-        <dd>WireMock is a-list free API mocking tool that can be run as a standalone server, or in a hosted version via the <a href="https://wiremock.io/">WireMock Cloud</a> managed service.</dd>
+        <dd>WireMock is a free API mocking tool that can be run as a standalone server, or in a hosted version via the <a href="https://wiremock.io/">WireMock Cloud</a> managed service.</dd>
 
         <dt><i class="faq-list-arrow"></i> What is API mocking?</dt>
-        <dd>API mocking i-listnvolves creating a simple simulation of an API, accepting the same types of request and returning identically structured responses as the real thing, enabling fast and reliable development and testing.</dd>
+        <dd>API mocking involves creating a simple simulation of an API, accepting the same types of request and returning identically structured responses as the real thing, enabling fast and reliable development and testing.</dd>
 
         <dt><i class="faq-list-arrow"></i> When do you need to mock APIs?</dt>
-        <dd>API mocking i-lists typically used during development and testing as it allows you to build your app without worrying about 3rd party APIs or sandboxes breaking. It can also be used to rapidly prototype APIs that don’t exist yet.</dd>
+        <dd>API mocking is typically used during development and testing as it allows you to build your app without worrying about 3rd party APIs or sandboxes breaking. It can also be used to rapidly prototype APIs that don’t exist yet.</dd>
 
         <dt><i class="faq-list-arrow"></i> How do you create an API mock?</dt>
-        <dd>WireMock supp-listorts several approaches for creating mock APIs - in code, via its REST API, as JSON files and by recording HTTP traffic proxied to another destination.</dd>
+        <dd>WireMock supports several approaches for creating mock APIs - in code, via its REST API, as JSON files and by recording HTTP traffic proxied to another destination.</dd>
 
         <dt><i class="faq-list-arrow"></i> What makes WireMock unique?</dt>
-        <dd>WireMock has -lista rich <a href="/docs/request-matching/">matching system</a>, allowing any part of an incoming request to be matched against complex and precise criteria. Responses of any complexity can be dynamically generated via the Handlebars based templating system. Finally, WireMock is easy to integrate into any workflow due to its numerous <a href="/docs/extending-wiremock/">extension points</a> and comprehensive APIs.</dd>
+        <dd>WireMock has a rich <a href="/docs/request-matching/">matching system</a>, allowing any part of an incoming request to be matched against complex and precise criteria. Responses of any complexity can be dynamically generated via the Handlebars based templating system. Finally, WireMock is easy to integrate into any workflow due to its numerous <a href="/docs/extending-wiremock/">extension points</a> and comprehensive APIs.</dd>
 
         <dt><i class="faq-list-arrow"></i> Is WireMock open source?</dt>
-        <dd>Yes, WireMock-list is a completely open source API mocking tool (<a href="https://github.com/wiremock/wiremock">GitHub repo</a>). If you’re looking for a hosted version of WireMock, check out <a href="https://wiremock.io/">WireMock Cloud</a>.</dd>
+        <dd>Yes, WireMock is a completely open source API mocking tool (<a href="https://github.com/wiremock/wiremock">GitHub repo</a>). If you’re looking for a hosted version of WireMock, check out <a href="https://wiremock.io/">WireMock Cloud</a>.</dd>
 
         <dt><i class="faq-list-arrow"></i> Is WireMock a free service?</dt>
         <dd>WireMock is completely free under the Apache 2.0 license.</dd>


### PR DESCRIPTION
I noticed a bunch of "-list" strings out of place in the FAQ section of the front page.
It looks like they were added in while adding CSS classnames to the elements above, so I removed them to show the right descriptions.