### PR TITLE
Modify all website Slack links to use the redirect

### DIFF
--- a/_config.yml
+++ b/_config.yml
@@ -217,4 +217,4 @@ wiremock_version: 2.35.0
 wiremock_beta_version: 3.0.0-beta-2
 
 community_slack:
-  join_url: https://join.slack.com/t/wiremock-community/shared_invite/zt-1mkbo0zlx-gxeZdTJ15Kchdt888Fn_1A
+  join_url: http://slack.wiremock.org/

--- a/_data/navigation.yml
+++ b/_data/navigation.yml
@@ -22,7 +22,7 @@ main:
           - name: "GitHub"
             subnavLink: "https://github.com/wiremock/wiremock"
           - name: "Slack"
-            subnavLink: "https://join.slack.com/t/wiremock-community/shared_invite/zt-1mkbo0zlx-gxeZdTJ15Kchdt888Fn_1A"
+            subnavLink: "http://slack.wiremock.org/"
           - name: "Slack archive"
             subnavLink: "https://community.wiremock.io/"
           - name: "Contributing"

--- a/index.html
+++ b/index.html
@@ -72,7 +72,7 @@ description: WireMock is a tool for building mock APIs. API mocking enables you 
       <div style="margin-top: 40px;display:flex;flex-wrap:wrap;gap: 5px;">
         <a href="#open-source-get-started" class="btn-primary">Get started</a>
         <a href="/docs/" class="btn-secondary">View docs</a>
-        <a href="https://join.slack.com/t/wiremock-community/shared_invite/zt-1mkbo0zlx-gxeZdTJ15Kchdt888Fn_1A" class="btn-secondary">Slack community</a>
+        <a href="http://slack.wiremock.org/" class="btn-secondary">Slack community</a>
       </div>
     </div>
     <div class="home-header-hero-image">

--- a/support/index.md
+++ b/support/index.md
@@ -9,7 +9,7 @@ description: How to get support for WireMock open source and Studio
 
 <br />
 
-If you're looking for help or advice you can find a community of users and contributors on the [WireMock community Slack](https://join.slack.com/t/wiremock-community/shared_invite/zt-1mkbo0zlx-gxeZdTJ15Kchdt888Fn_1A){:target="{{site.data.misc.blank}}"}.
+If you're looking for help or advice you can find a community of users and contributors on the [WireMock community Slack](http://slack.wiremock.org/){:target="{{site.data.misc.blank}}"}.
 
 <br />
 [Stack Overflow](https://stackoverflow.com/questions/tagged/wiremock){:target="{{site.data.misc.blank}}"} also has many good WireMock questions and answers.


### PR DESCRIPTION
Related to #28 . The links got broken after the Trial Period was "granted" to the workspace, so we need another link which is now hidden behind a redirect

FTR the new link is https://join.slack.com/t/wiremock-community/shared_invite/zt-1sw1lgoie-dEYDoPb_BdoCY86JqIs7xg for now